### PR TITLE
Migrate database on Heroku release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+release: rake db:migrate


### PR DESCRIPTION
Heroku's release phase happens after the app is built, but before it's made available to end users. See [Heroku documentation](https://devcenter.heroku.com/articles/release-phase):

> Release phase enables you to run certain tasks before a new release of your app is deployed. 

We leverage this phase to migrate the database.