### PR TITLE
Add 'title' column to 'articles' table

### DIFF
--- a/db/migrate/20200315203723_add_title_to_articles.rb
+++ b/db/migrate/20200315203723_add_title_to_articles.rb
@@ -1,0 +1,5 @@
+class AddTitleToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :title, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_14_233044) do
+ActiveRecord::Schema.define(version: 2020_03_15_203723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_03_14_233044) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
+    t.text "title"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 


### PR DESCRIPTION
Related to https://github.com/maximevaillancourt/freshreader/issues/14.

In a later PR, we'll fetch the page title from the provided URL, and save it in the database to display it in the articles list.