### PR TITLE
Move request helper tests

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -2,7 +2,10 @@ module RequestHelper
   extend self
 
   def extract_title_from_page(url)
-    body = fetch(url).body
+    title_from_response_body(fetch(url).body)
+  end
+
+  def self.title_from_response_body(body)
     title = body&.match(/<title.*>(.*)<\/title>/m)&.[](1)&.strip&.force_encoding('UTF-8')
     HTMLEntities.new.decode(title) if title
   end

--- a/test/helpers/request_helper_test.rb
+++ b/test/helpers/request_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class RequestHelperTest < ActiveSupport::TestCase
+  test '.title_from_response_body parses non-utf8 characters' do
+    expected = '«Nous devons agir maintenant», dit Theresa Tam'
+    actual = RequestHelper.title_from_response_body("<title>\xC2\xABNous devons agir maintenant\xC2\xBB, dit Theresa Tam</title>")
+    assert_equal expected, actual
+
+    expected = 'Why I still use a ThinkPad X220 in 2019 — Maxime Vaillancourt'
+    actual = RequestHelper.title_from_response_body("<title>\n    \n      Why I still use a ThinkPad X220 in 2019 &mdash; Maxime Vaillancourt\n    \n  </title>")
+    assert_equal expected, actual
+
+    expected = 'Foobar'
+    actual = RequestHelper.title_from_response_body("<title data-enabled=\"true\">Foobar</title>")
+    assert_equal expected, actual
+  end
+end

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -42,18 +42,4 @@ class ArticleTest < ActiveSupport::TestCase
     article = Article.new(url: 'https://freshreader.app/', title: '', user: @user)
     assert article.valid?
   end
-
-  test '.title_from_response_body parses non-utf8 characters' do
-    expected = '«Nous devons agir maintenant», dit Theresa Tam'
-    actual = Article.title_from_response_body("<title>\xC2\xABNous devons agir maintenant\xC2\xBB, dit Theresa Tam</title>")
-    assert_equal expected, actual
-
-    expected = 'Why I still use a ThinkPad X220 in 2019 — Maxime Vaillancourt'
-    actual = Article.title_from_response_body("<title>\n    \n      Why I still use a ThinkPad X220 in 2019 &mdash; Maxime Vaillancourt\n    \n  </title>")
-    assert_equal expected, actual
-
-    expected = 'Foobar'
-    actual = Article.title_from_response_body("<title data-enabled=\"true\">Foobar</title>")
-    assert_equal expected, actual
-  end
 end


### PR DESCRIPTION
Forgot to move tests in #28. Merged too early, ignored CI.

Good thing we have CI that prevents deployments to production when the build fails :) 